### PR TITLE
remove magic string about protocol

### DIFF
--- a/vault-operator/pkg/vault/deploy_vault.go
+++ b/vault-operator/pkg/vault/deploy_vault.go
@@ -270,11 +270,11 @@ func statsdExporterContainer() v1.Container {
 		Ports: []v1.ContainerPort{{
 			Name:          "statsd",
 			ContainerPort: exporterStatsdPort,
-			Protocol:      "UDP",
+			Protocol:      v1.ProtocolUDP,
 		}, {
 			Name:          "prometheus",
 			ContainerPort: exporterPromPort,
-			Protocol:      "TCP",
+			Protocol:      v1.ProtocolTCP,
 		}},
 	}
 }


### PR DESCRIPTION
This PR will replace `TCP` and `UDP` magic string with `v1.ProtocolUDP` and `v1.ProtocolTCP`.