### PR TITLE
vault/cmd/.../main.go: update operator main.go

### DIFF
--- a/vault-operator/cmd/vault-operator/main.go
+++ b/vault-operator/cmd/vault-operator/main.go
@@ -6,9 +6,11 @@ import (
 
 	stub "github.com/operator-framework/operator-sdk-samples/vault-operator/pkg/stub"
 	sdk "github.com/operator-framework/operator-sdk/pkg/sdk"
+	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
 	"github.com/sirupsen/logrus"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func printVersion() {
@@ -19,7 +21,18 @@ func printVersion() {
 
 func main() {
 	printVersion()
-	sdk.Watch("vault.security.coreos.com/v1alpha1", "VaultService", "default", 5)
+
+	sdk.ExposeMetricsPort()
+
+	resource := "vault.security.coreos.com/v1alpha1"
+	kind := "VaultService"
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		logrus.Fatalf("failed to get watch namespace: %v", err)
+	}
+	resyncPeriod := 5
+	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
+	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())
 	sdk.Run(context.TODO())
 }


### PR DESCRIPTION
The old main.go file from the vault-operator was outdated and did
not work outside of the default namespace. This update resyncs it
based on the current main.go template, which supports non-default
namespaces.