### PR TITLE
memcached/test/e2e: use pointer to ctx, not struct

### DIFF
--- a/memcached-operator/Gopkg.lock
+++ b/memcached-operator/Gopkg.lock
@@ -218,7 +218,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:af1045d23f952f03f29338b6c884b94103ec9844813337075fd458b956b27fea"
+  digest = "1:a74c092a205da1dd1deac1aa1255a80af2cb1a9e1fb6bc6659c7e7ffb8b7d7c7"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
     "pkg/k8sclient",
@@ -230,7 +230,7 @@
     "version",
   ]
   pruneopts = ""
-  revision = "ef476a9ff59609311bbc943f88bd96e2bf623a23"
+  revision = "408e7567e74f54c3070d7b103ee177e97ca4514f"
 
 [[projects]]
   digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"

--- a/memcached-operator/cmd/memcached-operator/main.go
+++ b/memcached-operator/cmd/memcached-operator/main.go
@@ -31,7 +31,7 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("failed to get watch namespace: %v", err)
 	}
-	resyncPeriod := time.Duration(5)
+	resyncPeriod := time.Duration(5) * time.Second
 	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())

--- a/memcached-operator/cmd/memcached-operator/main.go
+++ b/memcached-operator/cmd/memcached-operator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"runtime"
+	"time"
 
 	stub "github.com/operator-framework/operator-sdk-samples/memcached-operator/pkg/stub"
 	sdk "github.com/operator-framework/operator-sdk/pkg/sdk"
@@ -30,7 +31,7 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("failed to get watch namespace: %v", err)
 	}
-	resyncPeriod := 5
+	resyncPeriod := time.Duration(5)
 	logrus.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(stub.NewHandler())

--- a/memcached-operator/test/e2e/memcached_test.go
+++ b/memcached-operator/test/e2e/memcached_test.go
@@ -118,7 +118,7 @@ func MemcachedCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = memcachedScaleTest(t, f, &ctx); err != nil {
+	if err = memcachedScaleTest(t, f, ctx); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/memcached-operator/test/e2e/memcached_test.go
+++ b/memcached-operator/test/e2e/memcached_test.go
@@ -51,7 +51,7 @@ func TestMemcached(t *testing.T) {
 	})
 }
 
-func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx framework.TestCtx) error {
+func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
 	namespace, err := ctx.GetNamespace()
 	if err != nil {
 		return fmt.Errorf("could not get namespace: %v", err)
@@ -74,6 +74,9 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx framework.Test
 	if err != nil {
 		return err
 	}
+	ctx.AddFinalizerFn(func() error {
+		return f.DynamicClient.Delete(goctx.TODO(), exampleMemcached)
+	})
 	// wait for example-memcached to reach 3 replicas
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-memcached", 3, retryInterval, timeout)
 	if err != nil {
@@ -115,7 +118,7 @@ func MemcachedCluster(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = memcachedScaleTest(t, f, ctx); err != nil {
+	if err = memcachedScaleTest(t, f, &ctx); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Golang is pass-by-value, so passing the value of ctx meant that
any finalizer functions added in memcachedScaleTest were not being
run. This commit changes that by using a pointer instead.

This also adds a finalizer function for the example-memcached CR, which is why we need to pass a pointer instead of the value.