### PR TITLE
Correcting README commands for running tests

### DIFF
--- a/memcached-operator/README.md
+++ b/memcached-operator/README.md
@@ -85,10 +85,11 @@ Then, configure the testing environment:
 
 ```
 $ export NAMESPACE="my-test"
-$ kubectl create deploy/crds/cache_v1alpha1_memcached_crd.yaml -n $NAMESPACE
-$ kubectl create deploy/service_account.yaml -n $NAMESPACE
-$ kubectl create deploy/role.yaml -n $NAMESPACE
-$ kubectl create deploy/role_binding.yaml -n $NAMESPACE
+$ kubectl create namespace $NAMESPACE
+$ kubectl create -f deploy/crds/cache_v1alpha1_memcached_crd.yaml -n $NAMESPACE
+$ kubectl create -f deploy/service_account.yaml -n $NAMESPACE
+$ kubectl create -f deploy/role.yaml -n $NAMESPACE
+$ kubectl create -f deploy/role_binding.yaml -n $NAMESPACE
 ```
 
 Finally, run the tests:


### PR DESCRIPTION
Test commands are missing `-f` and don't include creating the namespace.