### PR TITLE
memcached/.../memcached_controller: use status update

### DIFF
--- a/memcached-operator/pkg/controller/memcached/memcached_controller.go
+++ b/memcached-operator/pkg/controller/memcached/memcached_controller.go
@@ -151,7 +151,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 	// Update status.Nodes if needed
 	if !reflect.DeepEqual(podNames, memcached.Status.Nodes) {
 		memcached.Status.Nodes = podNames
-		err := r.client.Update(context.TODO(), memcached)
+		err := r.client.Status().Update(context.TODO(), memcached)
 		if err != nil {
 			reqLogger.Error(err, "Failed to update Memcached status.")
 			return reconcile.Result{}, err


### PR DESCRIPTION
This makes the memcached-operator sample use the status updater when updating the status. While the tests did pass, the status blocks weren't being updated since the status is now a subresource. This is not something that gets checked in the tests so it slipped through in the initial `v0.4.0` rebase PR.