### PR TITLE
fix(TypeMeta) : Remove TypeMeta declaration from the implementation o…

### DIFF
--- a/memcached-operator/.gitignore
+++ b/memcached-operator/.gitignore
@@ -1,3 +1,6 @@
+#IDEA
+.idea/*
+
 # Temporary Build Files
 build/_output
 build/_test

--- a/memcached-operator/pkg/controller/memcached/memcached_controller.go
+++ b/memcached-operator/pkg/controller/memcached/memcached_controller.go
@@ -167,10 +167,6 @@ func (r *ReconcileMemcached) deploymentForMemcached(m *cachev1alpha1.Memcached) 
 	replicas := m.Spec.Size
 
 	dep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/memcached-operator/test/e2e/memcached_test.go
+++ b/memcached-operator/test/e2e/memcached_test.go
@@ -37,12 +37,7 @@ var (
 )
 
 func TestMemcached(t *testing.T) {
-	memcachedList := &operator.MemcachedList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
-	}
+	memcachedList := &operator.MemcachedList{}
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, memcachedList)
 	if err != nil {
 		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
@@ -61,10 +56,6 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	// create memcached custom resource
 	exampleMemcached := &operator.Memcached{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-memcached",
 			Namespace: namespace,


### PR DESCRIPTION
**Description of the change:**
* Remove TypeMeta declaration from the implementation of the objects

Note that the TypeMeta struct and its values are automatically filled when an object is initialized in this way is unnecessary to add this values and indeed shows a not good practice at all since the dev can add wrong values which will cause issues as for example not allow the client GET the object. 

Following an example which could cause error just to example this scenario. 
```go
    ...
    route := &routev1.Route{
        TypeMeta: v1.TypeMeta{  // TODO (user): Remove the TypeMeta declared
            APIVersion: "v1",   // the correct value should be `"route.openshift.io/v1"`
            Kind:       "Route",
        },
        ObjectMeta: v1.ObjectMeta{
            Name:      name,
            Namespace: namespace,
            Labels:    ls,
        },
    }
    ...
```

Following an example of the issue faced, it is because of the `TypeMeta.APIVersion` informed is invalid for the resource object schema. It is not recommended declared the `TypeMeta` since it will be implicitly generated. 

```shell
get route: (no kind "Route" is registered for version "v1" in scheme "k8s.io/client-go/kubernetes/scheme/register.go:61")
```

**Motivation for the change:**

Face issues like the above example because of this unnecessary declaration. 