### PR TITLE
Don't manually specify TypeMeta field

### DIFF
--- a/memcached-operator/pkg/controller/memcached/memcached_controller.go
+++ b/memcached-operator/pkg/controller/memcached/memcached_controller.go
@@ -167,10 +167,6 @@ func (r *ReconcileMemcached) deploymentForMemcached(m *cachev1alpha1.Memcached) 
 	replicas := m.Spec.Size
 
 	dep := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/memcached-operator/test/e2e/memcached_test.go
+++ b/memcached-operator/test/e2e/memcached_test.go
@@ -37,12 +37,7 @@ var (
 )
 
 func TestMemcached(t *testing.T) {
-	memcachedList := &operator.MemcachedList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
-	}
+	memcachedList := &operator.MemcachedList{}
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, memcachedList)
 	if err != nil {
 		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
@@ -61,10 +56,6 @@ func memcachedScaleTest(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	// create memcached custom resource
 	exampleMemcached := &operator.Memcached{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Memcached",
-			APIVersion: "cache.example.com/v1alpha1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "example-memcached",
 			Namespace: namespace,

--- a/vault-operator/pkg/vault/deploy_etcd.go
+++ b/vault-operator/pkg/vault/deploy_etcd.go
@@ -19,10 +19,6 @@ const (
 // deployEtcdCluster creates an etcd cluster for the given vault's name via etcd operator.
 func deployEtcdCluster(v *api.VaultService) (*eopapi.EtcdCluster, error) {
 	ec := &eopapi.EtcdCluster{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       eopapi.EtcdClusterResourceKind,
-			APIVersion: eopapi.SchemeGroupVersion.String(),
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      EtcdNameForVault(v.Name),
 			Namespace: v.Namespace,

--- a/vault-operator/pkg/vault/deploy_vault.go
+++ b/vault-operator/pkg/vault/deploy_vault.go
@@ -72,10 +72,6 @@ func deployVault(v *api.VaultService) error {
 	configVaultServerTLS(&podTempl, v)
 
 	d := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.GetName(),
 			Namespace: v.GetNamespace(),
@@ -101,10 +97,6 @@ func deployVault(v *api.VaultService) error {
 	}
 
 	svc := &v1.Service{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Service",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      v.GetName(),
 			Namespace: v.GetNamespace(),

--- a/vault-operator/pkg/vault/sync_vault.go
+++ b/vault-operator/pkg/vault/sync_vault.go
@@ -17,10 +17,6 @@ import (
 // syncVaultClusterSize ensures that the vault cluster is at the desired size.
 func syncVaultClusterSize(vr *api.VaultService) error {
 	d := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vr.GetName(),
 			Namespace: vr.GetNamespace(),
@@ -49,10 +45,6 @@ func syncUpgrade(vr *api.VaultService, status *api.VaultServiceStatus) (err erro
 	}()
 
 	d := &appsv1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Deployment",
-			APIVersion: "apps/v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      vr.GetName(),
 			Namespace: vr.GetNamespace(),
@@ -104,10 +96,6 @@ func syncUpgrade(vr *api.VaultService, status *api.VaultServiceStatus) (err erro
 		// If it failed for some reason, kubelet will send SIGKILL after default grace period (30s) eventually.
 		// It take longer but the the lock will get released eventually on failure case.
 		p := &v1.Pod{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Pod",
-				APIVersion: "v1",
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      active,
 				Namespace: vr.GetNamespace(),

--- a/vault-operator/pkg/vault/tls.go
+++ b/vault-operator/pkg/vault/tls.go
@@ -31,10 +31,6 @@ func prepareDefaultVaultTLSSecrets(vr *api.VaultService) (err error) {
 	// if TLS spec doesn't exist or secrets doesn't exist, then we can go create secrets.
 	if api.IsTLSConfigured(vr.Spec.TLS) {
 		se := &v1.Secret{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      vr.Spec.TLS.Static.ServerSecret,
 				Namespace: vr.Namespace,
@@ -92,10 +88,6 @@ func newVaultServerTLSSecret(vr *api.VaultService, caKey *rsa.PrivateKey, caCrt 
 // The client key and certificate are not generated since clients are not authenticated at the server
 func newVaultClientTLSSecret(vr *api.VaultService, caCrt *x509.Certificate) *v1.Secret {
 	return &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      api.DefaultVaultClientTLSSecretName(vr.Name),
 			Namespace: vr.Namespace,
@@ -117,10 +109,6 @@ func prepareEtcdTLSSecrets(vr *api.VaultService) (err error) {
 	}()
 
 	se := &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      EtcdClientTLSSecretName(vr.Name),
 			Namespace: vr.Namespace,
@@ -228,10 +216,6 @@ func newTLSSecret(vr *api.VaultService, caKey *rsa.PrivateKey, caCrt *x509.Certi
 		return nil, fmt.Errorf("new TLS secret failed: %v", err)
 	}
 	secret := &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: vr.Namespace,

--- a/vault-operator/pkg/vault/vault_config.go
+++ b/vault-operator/pkg/vault/vault_config.go
@@ -30,10 +30,6 @@ const (
 func prepareVaultConfig(vr *api.VaultService) error {
 	var cfgData string
 	cm := &v1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ConfigMap",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: vr.Namespace,
 		},

--- a/vault-operator/pkg/vault/vault_status.go
+++ b/vault-operator/pkg/vault/vault_status.go
@@ -28,12 +28,7 @@ func updateVaultStatus(vr *api.VaultService, status *api.VaultServiceStatus) err
 // getVaultStatus retrieves the status of the vault cluster for the given Custom Resource "vr",
 // and it only succeeds if all of the nodes from vault cluster are reachable.
 func getVaultStatus(vr *api.VaultService) (*api.VaultServiceStatus, error) {
-	pods := &v1.PodList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-	}
+	pods := &v1.PodList{}
 	sel := LabelsForVault(vr.Name)
 	opt := &metav1.ListOptions{LabelSelector: labels.SelectorFromSet(sel).String()}
 	err := sdk.List(vr.GetNamespace(), pods, sdk.WithListOptions(opt))
@@ -114,10 +109,6 @@ func NewVaultClient(hostname string, port string, tlsConfig *vaultapi.TLSConfig)
 func vaultTLSFromSecret(vr *api.VaultService) (*vaultapi.TLSConfig, error) {
 	cs := vr.Spec.TLS.Static.ClientSecret
 	se := &v1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cs,
 			Namespace: vr.GetNamespace(),

--- a/vault-operator/test/e2e/basic_test.go
+++ b/vault-operator/test/e2e/basic_test.go
@@ -19,12 +19,7 @@ func TestCreateHAVault(t *testing.T) {
 		t.Fatalf("could not initialize cluster resources: %v", err)
 	}
 
-	vaultServiceList := &api.VaultServiceList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "VaultService",
-			APIVersion: "vault.security.coreos.com/v1alpha1",
-		},
-	}
+	vaultServiceList := &api.VaultServiceList{}
 	err = framework.AddToFrameworkScheme(api.AddToScheme, vaultServiceList)
 	if err != nil {
 		t.Fatalf("could not add scheme to framework scheme: %v", err)

--- a/vault-operator/test/e2e/e2eutil/spec_util.go
+++ b/vault-operator/test/e2e/e2eutil/spec_util.go
@@ -9,10 +9,6 @@ import (
 // NewCluster returns a minimal vault cluster CR
 func NewCluster(genName, namespace string, size int) *api.VaultService {
 	return &api.VaultService{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       api.VaultServiceKind,
-			APIVersion: api.SchemeGroupVersion.String(),
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: genName,
 			Namespace:    namespace,

--- a/vault-operator/test/e2e/scale_test.go
+++ b/vault-operator/test/e2e/scale_test.go
@@ -19,12 +19,7 @@ func TestScaleUp(t *testing.T) {
 		t.Fatalf("could not initialize cluster resources: %v", err)
 	}
 
-	vaultServiceList := &api.VaultServiceList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "VaultService",
-			APIVersion: "vault.security.coreos.com/v1alpha1",
-		},
-	}
+	vaultServiceList := &api.VaultServiceList{}
 	err = framework.AddToFrameworkScheme(api.AddToScheme, vaultServiceList)
 	if err != nil {
 		t.Fatalf("could not add scheme to framework scheme: %v", err)

--- a/vault-operator/test/e2e/upgrade_test.go
+++ b/vault-operator/test/e2e/upgrade_test.go
@@ -19,12 +19,7 @@ func TestUpgradeVault(t *testing.T) {
 		t.Fatalf("could not initialize cluster resources: %v", err)
 	}
 
-	vaultServiceList := &api.VaultServiceList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "VaultService",
-			APIVersion: "vault.security.coreos.com/v1alpha1",
-		},
-	}
+	vaultServiceList := &api.VaultServiceList{}
 	err = framework.AddToFrameworkScheme(api.AddToScheme, vaultServiceList)
 	if err != nil {
 		t.Fatalf("could not add scheme to framework scheme: %v", err)


### PR DESCRIPTION
I originally started looking at this from the perspective of the test
examples, where something didn't look 100% to me, so I figured I'd
open a PR to start a discussion and figure out if my understanding is
correct or not.

Example:

Should the `Kind` in the following snippet not be `MemcachedList`
rather than `Memcached`?

```go
memcachedList := &operator.MemcachedList{
        TypeMeta: metav1.TypeMeta{
                Kind:       "Memcached",
                APIVersion: "cache.example.com/v1alpha1",
        },
}
```

I've seen the same thing in other operators, and I'm not sure if it's
the correct way, or if it's just wrong copied from this example.

As I think more about it, all of the correct information seems to be
inferrable from the type (`operator.MemcachedList`), so the `TypeMeta`
never needs to be added manually. Is that correct?

If it is, here's a pull request to remove it from everywhere that it's
manually specified here! :)