### PR TITLE
Remove Ansible .retry files

### DIFF
--- a/ansible/etcd-operator/ansible/roles/lookup/tasks/main.retry
+++ b/ansible/etcd-operator/ansible/roles/lookup/tasks/main.retry
@@ -1,1 +1,0 @@
-localhost

--- a/ansible/etcd-operator/ansible/roles/reconcile/tasks/main.retry
+++ b/ansible/etcd-operator/ansible/roles/reconcile/tasks/main.retry
@@ -1,1 +1,0 @@
-localhost


### PR DESCRIPTION
These are created by Ansible when a playbook fails. They should not be
committed to version control.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>