### PR TITLE
feat(MencacheExample) : Improve example in order to make more clear how it works

### DIFF
--- a/memcached-operator/pkg/controller/memcached/memcached_controller_test.go
+++ b/memcached-operator/pkg/controller/memcached/memcached_controller_test.go
@@ -72,7 +72,7 @@ func TestMemcachedController(t *testing.T) {
 		t.Error("reconcile did not requeue request as expected")
 	}
 
-	// Check if deployment has been created and has the correct size.
+	// Check if Deployment has been created and has the correct size.
 	dep := &appsv1.Deployment{}
 	err = cl.Get(context.TODO(), req.NamespacedName, dep)
 	if err != nil {
@@ -81,6 +81,22 @@ func TestMemcachedController(t *testing.T) {
 	dsize := *dep.Spec.Replicas
 	if dsize != replicas {
 		t.Errorf("dep size (%d) is not the expected size (%d)", dsize, replicas)
+	}
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+	// Check the result of reconciliation to make sure it has the desired state.
+	if res.Requeue {
+		t.Error("reconcile requeue which is not expected")
+	}
+
+	// Check if Service has been created.
+	ser := &corev1.Service{}
+	err = cl.Get(context.TODO(), req.NamespacedName, ser)
+	if err != nil {
+		t.Fatalf("get service: (%v)", err)
 	}
 
 	// Create the 3 expected pods in namespace and collect their names to check


### PR DESCRIPTION
## Motivation
https://github.com/operator-framework/operator-sdk/issues/1464

## What
- Add a service object
- Do not Requeue when it is not required. 
- Improve the test

## Why
- Make clear for users that are not required Requeue always 
- Make more clear how to CRUD the objects
- Make more clear how to test it since now has 2 objects and we can make show it better

## Steps to Verify:
- See here the changes: https://github.com/operator-framework/operator-sdk-samples/pull/67/commits/1dbcc41f4ac1ce75411583c6bb3d06abf4dc8cba
- Execute locally the CI test. 
<img width="1316" alt="Screenshot 2019-07-10 at 07 37 49" src="https://user-images.githubusercontent.com/7708031/60962848-a3c02580-a2e5-11e9-9f7f-ab2bdc4d5616.png">
### To check the project 
-  You can use the image: docker.io/cmacedo/mobile-security-service-operator:memcached-operator
- Run :

```
$ oc new-project memcached-operator
$ kubectl apply -f deploy/crds/cache_v1alpha1_memcached_crd.yaml
$ kubectl apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
$ kubectl apply -f deploy/role.yaml
$ kubectl apply -f deploy/role_binding.yaml
$ kubectl apply -f deploy/service_account.yaml
$ kubectl apply -f deploy/operator.yaml
```

- Check that all was installed and created with success in the cluster:

```shell
camilamacedo@Camilas-MacBook-Pro ~/go/src/operator-sdk-samples/memcached-operator (ISSUE_1464) $ oc get all
NAME                                     READY     STATUS    RESTARTS   AGE
pod/example-memcached-6dff74d47-968d4    1/1       Running   0          3m
pod/example-memcached-6dff74d47-mbcdw    1/1       Running   0          3m
pod/example-memcached-6dff74d47-njtk6    1/1       Running   0          3m
pod/memcached-operator-6b67b96d9-dwfm5   1/1       Running   0          3m

NAME                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
service/memcached-operator   ClusterIP   172.30.184.153   <none>        8383/TCP   3m

NAME                                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/example-memcached    3         3         3            3           3m
deployment.apps/memcached-operator   1         1         1            1           3m

NAME                                           DESIRED   CURRENT   READY     AGE
replicaset.apps/example-memcached-6dff74d47    3         3         3         3m
replicaset.apps/memcached-operator-6b67b96d9   1         1         1         3m

```

<img width="1674" alt="Screenshot 2019-07-10 at 07 46 54" src="https://user-images.githubusercontent.com/7708031/60963347-e9312280-a2e6-11e9-8739-284a901f2895.png">


IMPORTANT: the change is small, what was big here is the vendor update. See https://github.com/operator-framework/operator-sdk-samples/pull/67/commits/1dbcc41f4ac1ce75411583c6bb3d06abf4dc8cba