### PR TITLE
memcached/test/e2e: use WaitForOperatorDeployment

### DIFF
--- a/memcached-operator/test/e2e/memcached_test.go
+++ b/memcached-operator/test/e2e/memcached_test.go
@@ -105,7 +105,7 @@ func MemcachedCluster(t *testing.T) {
 	// get global framework variables
 	f := framework.Global
 	// wait for memcached-operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "memcached-operator", 1, retryInterval, timeout)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Use `WaitForOperatorDeployment` instead of `WaitForDeployment` when waiting for `memcached-operator`. This allows the `--up-local` flag to work properly.

Related to the conversation here: https://github.com/operator-framework/operator-sdk/issues/1830#issuecomment-527395768