### PR TITLE
Adjust Travisfile to install required jmespath dependency per operator-sdk #2023.

### DIFF
--- a/ansible/memcached-operator/.travis.yml
+++ b/ansible/memcached-operator/.travis.yml
@@ -2,6 +2,6 @@ sudo: required
 services: docker
 language: python
 install:
-  - pip3 install docker molecule openshift
+  - pip3 install docker molecule openshift jmespath
 script:
   - molecule test -s test-local


### PR DESCRIPTION
Please see https://github.com/operator-framework/operator-sdk/issues/2023 for more details.