### PR TITLE
Helm upgrade for 0.14.1

### DIFF
--- a/helm/memcached-operator/build/Dockerfile
+++ b/helm/memcached-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v0.13.0
+FROM quay.io/operator-framework/helm-operator:v0.14.1
 
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/

--- a/helm/memcached-operator/deploy/crds/cache.example.com_memcacheds_crd.yaml
+++ b/helm/memcached-operator/deploy/crds/cache.example.com_memcacheds_crd.yaml
@@ -12,6 +12,10 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true

--- a/helm/memcached-operator/deploy/role.yaml
+++ b/helm/memcached-operator/deploy/role.yaml
@@ -20,18 +20,21 @@ rules:
 - apiGroups:
   - policy
   resources:
+  - events
   - poddisruptionbudgets
   verbs:
   - '*'
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
   - services
   verbs:
   - '*'
 - apiGroups:
   - apps
   resources:
+  - deployments
   - statefulsets
   verbs:
   - '*'

--- a/helm/memcached-operator/watches.yaml
+++ b/helm/memcached-operator/watches.yaml
@@ -2,4 +2,4 @@
 - version: v1alpha1
   group: cache.example.com
   kind: Memcached
-  chart: /opt/helm/helm-charts/memcached
+  chart: helm-charts/memcached


### PR DESCRIPTION
**Description**
- Upgrade helm based image (Dockerfile)
- Upgrade scaffold files ( roles and crd )
- Upgrade watch since no longer is required to inform the full path. (https://github.com/operator-framework/operator-sdk/pull/2325)

**Local Test**

```
$ kubectl get all -n helm-memcached -o wide
NAME                                      READY   STATUS    RESTARTS   AGE   IP            NODE       NOMINATED NODE   READINESS GATES
pod/example-memcached-0                   1/1     Running   0          38s   172.17.0.8    minikube   <none>           <none>
pod/example-memcached-1                   1/1     Running   0          24s   172.17.0.9    minikube   <none>           <none>
pod/example-memcached-2                   1/1     Running   0          17s   172.17.0.10   minikube   <none>           <none>
pod/memcached-operator-5cb75b9864-r6j2w   1/1     Running   0          63s   172.17.0.7    minikube   <none>           <none>

NAME                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE   SELECTOR
service/example-memcached            ClusterIP   None            <none>        11211/TCP           38s   app=example-memcached
service/memcached-operator-metrics   ClusterIP   10.109.200.76   <none>        8686/TCP,8383/TCP   39s   name=memcached-operator

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS           IMAGES                                             SELECTOR
deployment.apps/memcached-operator   1/1     1            1           63s   memcached-operator   quay.io/camilamacedo86/memcached-operator:v0.0.1   name=memcached-operator

NAME                                            DESIRED   CURRENT   READY   AGE   CONTAINERS           IMAGES                                             SELECTOR
replicaset.apps/memcached-operator-5cb75b9864   1         1         1       63s   memcached-operator   quay.io/camilamacedo86/memcached-operator:v0.0.1   name=memcached-operator,pod-template-hash=5cb75b9864

NAME                                 READY   AGE   CONTAINERS          IMAGES
statefulset.apps/example-memcached   3/3     38s   example-memcached   memcached:1.5.12-alpine
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/operator-framework/operator-sdk-samples/helm/memcached-operator (helm-up-0.14.1) $ kubectl logs deployment.apps/memcached-operator -n helm-memcached
{"level":"info","ts":1582140428.8205788,"logger":"cmd","msg":"Go Version: go1.13.6"}
{"level":"info","ts":1582140428.8206816,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}
{"level":"info","ts":1582140428.820728,"logger":"cmd","msg":"Version of operator-sdk: v0.14.1"}
{"level":"info","ts":1582140428.8208709,"logger":"cmd","msg":"Watching single namespace.","Namespace":"helm-memcached"}
{"level":"info","ts":1582140429.1818833,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}
{"level":"info","ts":1582140429.1827364,"logger":"helm.controller","msg":"Watching resource","apiVersion":"cache.example.com/v1alpha1","kind":"Memcached","namespace":"helm-memcached","reconcilePeriod":"1m0s"}
{"level":"info","ts":1582140429.1829133,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1582140429.5533059,"logger":"leader","msg":"No pre-existing lock was found."}
{"level":"info","ts":1582140429.5600069,"logger":"leader","msg":"Became the leader."}
{"level":"info","ts":1582140430.322646,"logger":"metrics","msg":"Metrics Service object created","Service.Name":"memcached-operator-metrics","Service.Namespace":"helm-memcached"}
{"level":"info","ts":1582140430.3264465,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1582140430.3277023,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"memcached-controller","source":"kind source: cache.example.com/v1alpha1, Kind=Memcached"}
{"level":"info","ts":1582140430.328358,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"memcached-controller"}
{"level":"info","ts":1582140430.4289038,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"memcached-controller","worker count":1}
{"level":"info","ts":1582140431.1806061,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"memcached-controller","source":"kind source: policy/v1beta1, Kind=PodDisruptionBudget"}
{"level":"info","ts":1582140431.286286,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"cache.example.com/v1alpha1","ownerKind":"Memcached","apiVersion":"policy/v1beta1","kind":"PodDisruptionBudget"}
{"level":"info","ts":1582140431.286851,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"memcached-controller","source":"kind source: /v1, Kind=Service"}
{"level":"info","ts":1582140431.3888514,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"cache.example.com/v1alpha1","ownerKind":"Memcached","apiVersion":"v1","kind":"Service"}
{"level":"info","ts":1582140431.38996,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"memcached-controller","source":"kind source: apps/v1, Kind=StatefulSet"}
{"level":"info","ts":1582140431.49106,"logger":"helm.controller","msg":"Watching dependent resource","ownerApiVersion":"cache.example.com/v1alpha1","ownerKind":"Memcached","apiVersion":"apps/v1","kind":"StatefulSet"}
{"level":"info","ts":1582140431.4912035,"logger":"helm.controller","msg":"Installed release","namespace":"helm-memcached","name":"example-memcached","apiVersion":"cache.example.com/v1alpha1","kind":"Memcached","release":"example-memcached"}
+---
+# Source: memcached/templates/pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: example-memcached
+  labels:
+    app: example-memcached
+    chart: "memcached-3.0.1"
+    release: "example-memcached"
+    heritage: "Helm"
+spec:
+  selector:
+    matchLabels:
+      app: example-memcached
+      chart: "memcached-3.0.1"
+      release: "example-memcached"
+      heritage: "Helm"
+  minAvailable: 2
+---
+# Source: memcached/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-memcached
+  labels:
+    app: example-memcached
+    chart: "memcached-3.0.1"
+    release: "example-memcached"
+    heritage: "Helm"
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  ports:
+  - name: memcache
+    port: 11211
+    targetPort: memcache
+  selector:
+    app: example-memcached
+---
+# Source: memcached/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: example-memcached
+  labels:
+    app: example-memcached
+    chart: "memcached-3.0.1"
+    release: "example-memcached"
+    heritage: "Helm"
+spec:
+  selector:
+    matchLabels:
+      app: example-memcached
+      release: "example-memcached"
+  serviceName: example-memcached
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: example-memcached
+        chart: "memcached-3.0.1"
+        release: "example-memcached"
+        heritage: "Helm"
+    spec:
+      securityContext:
+        fsGroup: 1001
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 5
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app:  example-memcached
+                  release: "example-memcached"
+      containers:
+      - name: example-memcached
+        image: memcached:1.5.12-alpine
+        imagePullPolicy: ""
+        securityContext:
+          runAsUser: 1001
+        command:
+        - memcached
+        - -m 64
+        - -o
+        - modern
+        - -v
+        ports:
+        - name: memcache
+          containerPort: 11211
+        livenessProbe:
+          tcpSocket:
+            port: memcache
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          tcpSocket:
+            port: memcache
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+  updateStrategy:
+    type: RollingUpdate


```