### PR TITLE
update project to use relative paths in the watches

### DIFF
--- a/ansible/memcached-operator/watches.yaml
+++ b/ansible/memcached-operator/watches.yaml
@@ -2,4 +2,4 @@
 - version: v1alpha1
   group: cache.example.com
   kind: Memcached
-  role: /opt/ansible/roles/Memcached
+  role: Memcached


### PR DESCRIPTION
**Motivation**
- Allow users to check that in the 0.15.x they can use relative paths
- Allow we easily test locally it by running `operator-sdk run --local`