### PR TITLE
Upgrade Ansible Sample to use 0.17

### DIFF
--- a/ansible/memcached-operator/.travis.yml
+++ b/ansible/memcached-operator/.travis.yml
@@ -2,6 +2,6 @@
 services: docker
 language: python
 install:
-  - pip3 install docker molecule openshift jmespath
+  - pip3 install docker molecule ansible-lint yamllint flake8 openshift jmespath
 script:
   - molecule test -s test-local

--- a/ansible/memcached-operator/build/Dockerfile
+++ b/ansible/memcached-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.16.0
+FROM quay.io/operator-framework/ansible-operator:v0.17.0
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/ansible/memcached-operator/molecule/cluster/converge.yml
+++ b/ansible/memcached-operator/molecule/cluster/converge.yml
@@ -1,0 +1,24 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  collections:
+    - community.kubernetes
+
+  tasks:
+    - name: Ensure operator image is set
+      fail:
+        msg: |
+          You must specify the OPERATOR_IMAGE environment variable in order to run the
+          'cluster' scenario
+      when: not operator_image
+
+    - name: Create the Operator Deployment
+      k8s:
+        namespace: '{{ namespace }}'
+        definition: "{{ lookup('template', '/'.join([template_dir, 'operator.yaml.j2'])) }}"
+        wait: yes
+      vars:
+        image: '{{ operator_image }}'
+        pull_policy: '{{ operator_pull_policy }}'

--- a/ansible/memcached-operator/molecule/cluster/molecule.yml
+++ b/ansible/memcached-operator/molecule/cluster/molecule.yml
@@ -3,24 +3,22 @@ dependency:
   name: galaxy
 driver:
   name: delegated
-lint:
-  name: yamllint
-  options:
-    config-data:
-      line-length:
-        max: 120
+lint: |
+  set -e
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
 platforms:
 - name: cluster
   groups:
   - k8s
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
+  lint: |
+    set -e
+    ansible-lint
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-osdk-test}
+        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
     host_vars:
       localhost:
         ansible_python_interpreter: '{{ ansible_playbook_python }}'
@@ -32,5 +30,6 @@ provisioner:
     K8S_AUTH_KUBECONFIG: ${KUBECONFIG:-"~/.kube/config"}
 verifier:
   name: ansible
-  lint:
-    name: ansible-lint
+  lint: |
+    set -e
+    ansible-lint

--- a/ansible/memcached-operator/molecule/default/converge.yml
+++ b/ansible/memcached-operator/molecule/default/converge.yml
@@ -1,0 +1,6 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  roles:
+    - memcached

--- a/ansible/memcached-operator/molecule/default/molecule.yml
+++ b/ansible/memcached-operator/molecule/default/molecule.yml
@@ -3,19 +3,14 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
-  enabled: False
-  options:
-    config-data:
-      line-length:
-        max: 120
-
+lint: |
+  set -e
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
 platforms:
 - name: kind-default
   groups:
   - k8s
-  image: bsycorp/kind:latest-${KUBE_VERSION:-1.16}
+  image: bsycorp/kind:latest-${KUBE_VERSION:-1.17}
   privileged: True
   override_command: no
   exposed_ports:
@@ -27,13 +22,13 @@ platforms:
 provisioner:
   name: ansible
   log: True
-  lint:
-    name: ansible-lint
-    enabled: False
+  lint: |
+    set -e
+    ansible-lint
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-osdk-test}
+        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
         kubeconfig_file: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
     host_vars:
       localhost:
@@ -43,9 +38,8 @@ provisioner:
     KUBECONFIG: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
     ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
     KIND_PORT: '${TEST_CLUSTER_PORT:-9443}'
-scenario:
-  name: default
 verifier:
-  name: testinfra
-  lint:
-    name: flake8
+  name: ansible
+  lint: |
+    set -e
+    ansible-lint

--- a/ansible/memcached-operator/molecule/default/prepare.yml
+++ b/ansible/memcached-operator/molecule/default/prepare.yml
@@ -2,18 +2,10 @@
 - name: Prepare
   hosts: k8s
   gather_facts: no
-  vars:
-    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
   tasks:
-    - name: delete the kubeconfig if present
-      file:
-        path: '{{ kubeconfig }}'
-        state: absent
-      delegate_to: localhost
-
     - name: Fetch the kubeconfig
       fetch:
-        dest: '{{ kubeconfig }}'
+        dest: '{{ kubeconfig_file }}'
         flat: yes
         src: /root/.kube/config
 
@@ -21,7 +13,7 @@
       replace:
         regexp: '8443'
         replace: "{{ lookup('env', 'KIND_PORT') }}"
-        path: '{{ kubeconfig }}'
+        path: '{{ kubeconfig_file }}'
       delegate_to: localhost
 
     - name: Wait for the Kubernetes API to become available (this could take a minute)

--- a/ansible/memcached-operator/molecule/test-local/converge.yml
+++ b/ansible/memcached-operator/molecule/test-local/converge.yml
@@ -1,0 +1,42 @@
+---
+- name: Build Operator in Kubernetes docker container
+  hosts: k8s
+  collections:
+   - community.kubernetes
+
+  vars:
+    image: cache.example.com/memcached-operator:testing
+
+  tasks:
+    # using command so we don't need to install any dependencies
+    - name: Get existing image hash
+      command: docker images -q {{ image }}
+      register: prev_hash_raw
+      changed_when: false
+
+    - name: Build Operator Image
+      command: docker build -f /build/build/Dockerfile -t {{ image }} /build
+      register: build_cmd
+      changed_when: not hash or (hash and hash not in cmd_out)
+      vars:
+        hash: '{{ prev_hash_raw.stdout }}'
+        cmd_out: '{{ "".join(build_cmd.stdout_lines[-2:]) }}'
+
+- name: Converge
+  hosts: localhost
+  connection: local
+  collections:
+   - community.kubernetes
+
+  vars:
+    image: cache.example.com/memcached-operator:testing
+    operator_template: "{{ '/'.join([template_dir, 'operator.yaml.j2']) }}"
+
+  tasks:
+    - name: Create the Operator Deployment
+      k8s:
+        namespace: '{{ namespace }}'
+        definition: "{{ lookup('template', operator_template) }}"
+        wait: yes
+      vars:
+        pull_policy: Never

--- a/ansible/memcached-operator/molecule/test-local/molecule.yml
+++ b/ansible/memcached-operator/molecule/test-local/molecule.yml
@@ -3,19 +3,14 @@ dependency:
   name: galaxy
 driver:
   name: docker
-lint:
-  name: yamllint
-  enabled: False
-  options:
-    config-data:
-      line-length:
-        max: 120
-
+lint: |
+  set -e
+  yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" .
 platforms:
   - name: kind-test-local
     groups:
       - k8s
-    image: bsycorp/kind:latest-${KUBE_VERSION:-1.16}
+    image: bsycorp/kind:latest-${KUBE_VERSION:-1.17}
     privileged: true
     override_command: false
     exposed_ports:
@@ -28,14 +23,13 @@ platforms:
       - ${MOLECULE_PROJECT_DIRECTORY}:/build:Z
 provisioner:
   name: ansible
-  log: True
+  log: true
   lint:
     name: ansible-lint
-    enabled: False
   inventory:
     group_vars:
       all:
-        namespace: ${TEST_NAMESPACE:-osdk-test}
+        namespace: ${TEST_OPERATOR_NAMESPACE:-osdk-test}
         kubeconfig_file: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
     host_vars:
       localhost:
@@ -61,6 +55,6 @@ scenario:
     - verify
     - destroy
 verifier:
-  name: testinfra
+  name: ansible
   lint:
-    name: flake8
+    name: ansible-lint


### PR DESCRIPTION
**Description**
- Upgrade Ansible Sample to use 0.17

**Motivation**
Release of SDK 0.17

**Local Test**
```
$ kubectl get all -n memcached
NAME                                               READY   STATUS    RESTARTS   AGE
pod/example-memcached-memcached-6456bdd5fc-4xvkz   1/1     Running   0          7s
pod/example-memcached-memcached-6456bdd5fc-7shxl   1/1     Running   0          7s
pod/example-memcached-memcached-6456bdd5fc-cwdm9   1/1     Running   0          7s
pod/memcached-operator-864bbcd-tsc2c               1/1     Running   0          51s

NAME                                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
service/memcached-operator-metrics   ClusterIP   10.111.142.126   <none>        8383/TCP,8686/TCP   16s

NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/example-memcached-memcached   3/3     3            3           7s
deployment.apps/memcached-operator            1/1     1            1           51s

NAME                                                     DESIRED   CURRENT   READY   AGE
replicaset.apps/example-memcached-memcached-6456bdd5fc   3         3         3       7s
replicaset.apps/memcached-operator-864bbcd               1         1         1       51s
```
