### PR TITLE
Upgrade Helm Sample to use sdk 0.17

### DIFF
--- a/helm/memcached-operator/build/Dockerfile
+++ b/helm/memcached-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v0.16.0
+FROM quay.io/operator-framework/helm-operator:v0.17.0
 
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/

--- a/helm/memcached-operator/deploy/operator.yaml
+++ b/helm/memcached-operator/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: memcached-operator
           # Replace this with the built image name
-          image: "REPLACE_IMAGE"
+          image: REPLACE_IMAGE
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/helm/memcached-operator/helm-charts/memcached/README.md
+++ b/helm/memcached-operator/helm-charts/memcached/README.md
@@ -128,18 +128,4 @@ spec:
 
 Once you've done this, you can upgrade to 3.x with Helm as normal.
 
-If you want prometheus-operator scrap all serviceMonitors in your cluster you need to set:
-```yaml
-prometheus:
-  prometheusSpec:
-    serviceMonitorSelectorNilUsesHelmValues: false
-```
-If you want to be specific:
-```yaml
-prometheus:
-  prometheusSpec:
-    serviceMonitorSelector:
-      matchLabels:
-        app: memcached
-```
-You can have more intel in prometheus-operator values and here [github](https://github.com/helm/charts/issues/11310#issuecomment-463486706)
+

--- a/helm/memcached-operator/helm-charts/memcached/README.md
+++ b/helm/memcached-operator/helm-charts/memcached/README.md
@@ -47,8 +47,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `memcached.verbosity`      | Verbosity level (v, vv, or vvv) | Un-set.                                                 |
 | `memcached.maxItemMemory`  | Max memory for items (in MB)    | `64`                                                    |
 | `memcached.extraArgs`      | Additional memcached arguments  | `[]`                                                    |
-| `metrics.enabled`          | Expose metrics in prometheus format | false                                              
-             
+| `metrics.enabled`          | Expose metrics in prometheus format | false                                               |             
 | `metrics.image`            | The image to pull and run for the metrics exporter | A recent official memcached tag      |
 | `metrics.imagePullPolicy`  | Image pull policy               | `Always` if `imageTag` is `latest`, else `IfNotPresent` |
 | `metrics.resources`        | CPU/Memory resource requests/limits for the metrics exporter | `{}`                       |
@@ -129,4 +128,18 @@ spec:
 
 Once you've done this, you can upgrade to 3.x with Helm as normal.
 
-
+If you want prometheus-operator scrap all serviceMonitors in your cluster you need to set:
+```yaml
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+```
+If you want to be specific:
+```yaml
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelector:
+      matchLabels:
+        app: memcached
+```
+You can have more intel in prometheus-operator values and here [github](https://github.com/helm/charts/issues/11310#issuecomment-463486706)

--- a/helm/memcached-operator/helm-charts/memcached/values.yaml
+++ b/helm/memcached-operator/helm-charts/memcached/values.yaml
@@ -77,6 +77,9 @@ securityContext:
 metrics:
   ## Expose memcached metrics in Prometheus format
   enabled: false
+  serviceMonitor:
+    enabled: false
+    interval: 15s
 
   ## Memcached exporter image and tag
   image: quay.io/prometheus/memcached-exporter:v0.6.0
@@ -93,7 +96,9 @@ metrics:
   resources: {}
 
 extraContainers: |
+
 extraVolumes: |
+
 ## Custom metadata labels to be applied to statefulset and pods
 # podLabels:
 #   foo: "bar"


### PR DESCRIPTION
**Description**
- Upgrade Helm Sample to use 0.17

**Motivation**
Release of SDK 0.17

**Local Test**
```
 $ kubectl get all -n helm-memcached -o wide
NAME                                      READY   STATUS    RESTARTS   AGE   IP           NODE       NOMINATED NODE   READINESS GATES
pod/example-memcached-0                   1/1     Running   0          27s   172.17.0.6   minikube   <none>           <none>
pod/example-memcached-1                   1/1     Running   0          16s   172.17.0.7   minikube   <none>           <none>
pod/example-memcached-2                   0/1     Running   0          3s    172.17.0.8   minikube   <none>           <none>
pod/memcached-operator-5459696774-pcwjs   1/1     Running   0          33s   172.17.0.4   minikube   <none>           <none>

NAME                                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE   SELECTOR
service/example-memcached            ClusterIP   None           <none>        11211/TCP           27s   app.kubernetes.io/instance=example-memcached,app.kubernetes.io/name=memcached
service/memcached-operator-metrics   ClusterIP   10.107.87.71   <none>        8383/TCP,8686/TCP   29s   name=memcached-operator

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS           IMAGES                                             SELECTOR
deployment.apps/memcached-operator   1/1     1            1           33s   memcached-operator   quay.io/camilamacedo86/memcached-operator:v0.0.1   name=memcached-operator

NAME                                            DESIRED   CURRENT   READY   AGE   CONTAINERS           IMAGES                                             SELECTOR
replicaset.apps/memcached-operator-5459696774   1         1         1       33s   memcached-operator   quay.io/camilamacedo86/memcached-operator:v0.0.1   name=memcached-operator,pod-template-hash=5459696774

NAME                                 READY   AGE   CONTAINERS          IMAGES
statefulset.apps/example-memcached   2/3     27s   example-memcached   memcached:1.5.20


```
