### PR TITLE
feat: upgrade Ansible sample to use 0.18.1 SDK version

### DIFF
--- a/ansible/memcached-operator/build/Dockerfile
+++ b/ansible/memcached-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.17.0
+FROM quay.io/operator-framework/ansible-operator:v0.18.0
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/ansible/memcached-operator/build/Dockerfile
+++ b/ansible/memcached-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.18.0
+FROM quay.io/operator-framework/ansible-operator:v0.18.1
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/ansible/memcached-operator/deploy/crds/cache.example.com_memcacheds_crd.yaml
+++ b/ansible/memcached-operator/deploy/crds/cache.example.com_memcacheds_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: memcacheds.cache.example.com
@@ -10,13 +10,13 @@ spec:
     plural: memcacheds
     singular: memcached
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/ansible/memcached-operator/deploy/operator.yaml
+++ b/ansible/memcached-operator/deploy/operator.yaml
@@ -39,6 +39,12 @@ spec:
               value: "4"
             - name: ANSIBLE_DEBUG_LOGS
               value: "True"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 6789
+            initialDelaySeconds: 5
+            periodSeconds: 3
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/memcached-operator/molecule/templates/operator.yaml.j2
+++ b/ansible/memcached-operator/molecule/templates/operator.yaml.j2
@@ -35,6 +35,13 @@ spec:
               value: "memcached-operator"
             - name: ANSIBLE_GATHERING
               value: explicit
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 6789
+            initialDelaySeconds: 5
+            periodSeconds: 3
+
       volumes:
         - name: runner
           emptyDir: {}

--- a/ansible/memcached-operator/roles/memcached/README.md
+++ b/ansible/memcached-operator/roles/memcached/README.md
@@ -1,0 +1,43 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance,
+if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in 
+defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables 
+that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set
+for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for
+users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/ansible/memcached-operator/roles/memcached/defaults/main.yml
+++ b/ansible/memcached-operator/roles/memcached/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for Memcached
+size: 1

--- a/ansible/memcached-operator/roles/memcached/handlers/main.yml
+++ b/ansible/memcached-operator/roles/memcached/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for memcached

--- a/ansible/memcached-operator/roles/memcached/meta/main.yml
+++ b/ansible/memcached-operator/roles/memcached/meta/main.yml
@@ -1,0 +1,64 @@
+---
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+collections:
+- operator_sdk.util
+- community.kubernetes

--- a/ansible/memcached-operator/roles/memcached/tasks/main.yml
+++ b/ansible/memcached-operator/roles/memcached/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# tasks file for Memcached
+- name: start memcached
+  k8s:
+    definition:
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: '{{ meta.name }}-memcached'
+        namespace: '{{ meta.namespace }}'
+      spec:
+        replicas: "{{size}}"
+        selector:
+          matchLabels:
+            app: memcached
+        template:
+          metadata:
+            labels:
+              app: memcached
+          spec:
+            containers:
+            - name: memcached
+              command:
+              - memcached
+              - -m=64
+              - -o
+              - modern
+              - -v
+              image: "docker.io/memcached:1.4.36-alpine"
+              ports:
+                - containerPort: 11211

--- a/ansible/memcached-operator/roles/memcached/tests/inventory
+++ b/ansible/memcached-operator/roles/memcached/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/ansible/memcached-operator/roles/memcached/tests/test.yml
+++ b/ansible/memcached-operator/roles/memcached/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - Memcached

--- a/ansible/memcached-operator/roles/memcached/tests/test.yml
+++ b/ansible/memcached-operator/roles/memcached/tests/test.yml
@@ -3,3 +3,4 @@
   remote_user: root
   roles:
     - Memcached
+    

--- a/ansible/memcached-operator/roles/memcached/vars/main.yml
+++ b/ansible/memcached-operator/roles/memcached/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for memcached


### PR DESCRIPTION
Upgrade the Ansible to use the SDK 0.18

Local test: 

```
$ kubectl get all -n memcached
NAME                                               READY   STATUS    RESTARTS   AGE
pod/example-memcached-memcached-6456bdd5fc-5sff9   1/1     Running   0          44s
pod/example-memcached-memcached-6456bdd5fc-jl8d5   1/1     Running   0          44s
pod/example-memcached-memcached-6456bdd5fc-rf586   1/1     Running   0          44s
pod/memcached-operator-7bb5fb9d9c-cd4qb            1/1     Running   0          55s

NAME                                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
service/memcached-operator-metrics   ClusterIP   10.110.98.29   <none>        8383/TCP,8686/TCP   50s

NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/example-memcached-memcached   3/3     3            3           44s
deployment.apps/memcached-operator            1/1     1            1           55s

NAME                                                     DESIRED   CURRENT   READY   AGE
replicaset.apps/example-memcached-memcached-6456bdd5fc   3         3         3       44s
replicaset.apps/memcached-operator-7bb5fb9d9c            1         1         1       55s
```