### PR TITLE
upgrade helm sample to use sdk 0.18.1

### DIFF
--- a/helm/memcached-operator/build/Dockerfile
+++ b/helm/memcached-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v0.17.0
+FROM quay.io/operator-framework/helm-operator:v0.18.1
 
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/

--- a/helm/memcached-operator/deploy/crds/cache.example.com_memcacheds_crd.yaml
+++ b/helm/memcached-operator/deploy/crds/cache.example.com_memcacheds_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: memcacheds.cache.example.com
@@ -10,13 +10,13 @@ spec:
     plural: memcacheds
     singular: memcached
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/helm/memcached-operator/helm-charts/memcached/Chart.yaml
+++ b/helm/memcached-operator/helm-charts/memcached/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 name: memcached
 sources:
 - https://github.com/docker-library/memcached
-version: 3.2.2
+version: 3.2.3

--- a/helm/memcached-operator/helm-charts/memcached/templates/statefulset.yaml
+++ b/helm/memcached-operator/helm-charts/memcached/templates/statefulset.yaml
@@ -122,7 +122,11 @@ spec:
       affinity:
 {{ toYaml . | trim | indent 8}}
 {{- end }}
+{{- if eq .Values.kind "StatefulSet" }}
   updateStrategy:
+{{- else }}
+  strategy:
+{{- end }}
     type: {{ .Values.updateStrategy.type }}
     {{- if (eq "Recreate" .Values.updateStrategy.type) }}
     rollingUpdate: null

--- a/helm/memcached-operator/watches.yaml
+++ b/helm/memcached-operator/watches.yaml
@@ -1,5 +1,5 @@
 ---
-- version: v1alpha1
-  group: cache.example.com
+- group: cache.example.com
+  version: v1alpha1
   kind: Memcached
   chart: helm-charts/memcached


### PR DESCRIPTION


**Local Test**

```shell
$ kubectl get all -n helm-memcached
NAME                                      READY   STATUS    RESTARTS   AGE
pod/example-memcached-0                   1/1     Running   0          34s
pod/example-memcached-1                   0/1     Running   0          8s
pod/memcached-operator-5459696774-x7l66   1/1     Running   0          56s

NAME                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
service/example-memcached            ClusterIP   None            <none>        11211/TCP           34s
service/memcached-operator-metrics   ClusterIP   10.111.227.89   <none>        8383/TCP,8686/TCP   35s

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/memcached-operator   1/1     1            1           56s

NAME                                            DESIRED   CURRENT   READY   AGE
replicaset.apps/memcached-operator-5459696774   1         1         1       56s

NAME                                 READY   AGE
statefulset.apps/example-memcached   1/3     34s
```