### PR TITLE
upgrade helm sample 0.19.2

### DIFF
--- a/helm/memcached-operator/build/Dockerfile
+++ b/helm/memcached-operator/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/helm-operator:v0.18.1
+FROM quay.io/operator-framework/helm-operator:v0.19.2
 
 COPY watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/ ${HOME}/helm-charts/

--- a/helm/memcached-operator/helm-charts/memcached/README.md
+++ b/helm/memcached-operator/helm-charts/memcached/README.md
@@ -2,7 +2,7 @@
 
 > [Memcached](https://memcached.org/) is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 
-Based on the [memcached](https://github.com/bitnami/charts/tree/master/incubator/memcached) chart from the [Bitnami Charts](https://github.com/bitnami/charts) repository.
+Based on the Bitnami [memcached chart](https://github.com/bitnami/charts/tree/master/bitnami/memcached).
 
 ## TL;DR;
 

--- a/helm/memcached-operator/helm-charts/memcached/README.md
+++ b/helm/memcached-operator/helm-charts/memcached/README.md
@@ -2,7 +2,7 @@
 
 > [Memcached](https://memcached.org/) is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 
-Based on the [memcached](https://github.com/helm/charts/tree/master/stable/memcached) chart from the [Helm Charts](https://github.com/helm/charts) repository.
+Based on the [memcached](https://github.com/bitnami/charts/tree/master/incubator/memcached) chart from the [Bitnami Charts](https://github.com/bitnami/charts) repository.
 
 ## TL;DR;
 


### PR DESCRIPTION
**Description**
- Upgrade Helm Sample to use 0.19.2

**Local Test**

```
$ kubectl get all -n helm-memcached 
NAME                                      READY   STATUS    RESTARTS   AGE
pod/example-memcached-0                   1/1     Running   0          111s
pod/example-memcached-1                   1/1     Running   0          94s
pod/example-memcached-2                   1/1     Running   0          82s
pod/memcached-operator-5459696774-krcgg   1/1     Running   0          2m9s

NAME                                 TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
service/example-memcached            ClusterIP   None             <none>        11211/TCP           111s
service/memcached-operator-metrics   ClusterIP   10.107.150.102   <none>        8383/TCP,8686/TCP   113s

NAME                                 READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/memcached-operator   1/1     1            1           2m9s

NAME                                            DESIRED   CURRENT   READY   AGE
replicaset.apps/memcached-operator-5459696774   1         1         1       2m9s

NAME                                 READY   AGE
statefulset.apps/example-memcached   3/3     111s

```

@Co-authored-by: @theishshah 