### PR TITLE
Raise the Helm operator controller-manager memory limit to 200Mi.

### DIFF
--- a/helm/memcached-operator/config/manager/manager.yaml
+++ b/helm/memcached-operator/config/manager/manager.yaml
@@ -31,7 +31,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 90Mi
+            memory: 200Mi
           requests:
             cpu: 100m
             memory: 60Mi


### PR DESCRIPTION
Fixes #156.﻿
