### PR TITLE
Main Sample Gen Script

### DIFF
--- a/.generate/gen-all.sh
+++ b/.generate/gen-all.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+#  Copyright 2019 The Operator-SDK Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -o errexit
+set -o pipefail
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 test.sh
+NO_COLOR=${NO_COLOR:-""}
+if [ -z "$NO_COLOR" ]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+HELM_SCRIPT_PATH="../helm/.generate/gen-helm-memcached.sh"
+GO_SCRIPT_PATH="../go/.generate/gen-go-sample.sh"
+ANS_SCRIPT_PATH="../ansible/.generate/gen-ansible-memcached.sh"
+
+RELEASE_VERSION=v1.0.0
+
+header_text "downloading binaries"
+
+curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu
+curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu
+
+header_text "installing operator-sdk"
+
+chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk && rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
+chmod +x ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/ansible-operator && rm ansible-operator-${RELEASE_VERSION}-x86_64-linux-gnu
+chmod +x helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu && sudo mkdir -p /usr/local/bin/ && sudo cp helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/helm-operator && rm helm-operator-${RELEASE_VERSION}-x86_64-linux-gnu
+
+HELM_OUTPUT=`"$HELM_SCRIPT_PATH"`
+echo $HELM_OUTPUT
+
+GO_OUTPUT=`"$GO_SCRIPT_PATH"`
+echo $GO_OUTPUT
+
+ANS_OUTPUT=`"$ANS_SCRIPT_PATH"`
+echo $ANS_OUTPUT


### PR DESCRIPTION
This script will download and install the 1.0 operator-sdk binary and proceed to run the existing generate scripts for each of helm, go, and ansible samples. 